### PR TITLE
docs: drop invite-only framing for Batch beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ that endpoint with extraction parameters, not a separate product.
 | --- | --- | --- |
 | `zenrows fetch` | Universal Scraper API — retrieve a protected page | **available** — `GET https://api.zenrows.com/v1/` |
 | `zenrows extract` | Universal Scraper API — structured extraction (Autoparse / CSS / Markdown) | **available** — same `/v1/` |
-| `zenrows batch` | Batch Scraper API — fan out over many URLs | beta (invite only) — cloud works with beta access; local validate/estimate always |
+| `zenrows batch` | Batch Scraper API — fan out over many URLs | beta — cloud works with beta access; local validate/estimate always |
 | `zenrows browser` | Scraping Browser (CDP) / MCP escalation | experimental |
 | `zenrows mcp` | MCP server config (remote + local) | **available** |
 | ZenRows CLI | this repo | available |
@@ -115,11 +115,11 @@ zenrows extract <url> --css '{"title":"h1","price":".price"}' --validate
 zenrows extract <url> --output markdown
 ```
 
-## 9. Batch (beta, invite only)
+## 9. Batch (beta)
 
 The ZenRows **Batch Scraper API** (`https://async.api.zenrows.com/v1`) fans a
 protected fetch/extract out over many URLs. It is a real product in
-**private/invite-only beta**: the cloud subcommands work once your API key has
+**beta**: the cloud subcommands work once your API key has
 beta access; without it the API returns `BATCH_ACCESS_DENIED`. Local spec
 validation + credit estimation always work (no key needed).
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -8,7 +8,7 @@ the single source of truth that prevents hallucinated execution.
 - **available** — a documented endpoint exists and the command does real work.
 - **available-but-needs-confirmation** — likely available; verify per account.
 - **experimental** — exists but gated (e.g. browser, behind `policy.allow_browser`).
-- **beta** — real product in private/invite-only beta; limited access (local spec / validation works today, cloud execution needs beta access).
+- **beta** — real product in beta; limited access (local spec / validation works today, cloud execution needs beta access).
 - **planned** — no documented endpoint yet; local spec / validation only.
 - **not-implemented** / **deprecated** — not usable.
 
@@ -20,7 +20,7 @@ Classification is based on the public ZenRows documentation:
 | --- | --- | --- |
 | `protected_fetch` | Universal Scraper API `GET https://api.zenrows.com/v1/` with `mode`, `js_render`, `premium_proxy`, `proxy_country`, `wait`/`wait_for`, `js_instructions`, `response_type`, `screenshot`, `original_status`, … | available |
 | `extract` | Same `/v1/` endpoint via `autoparse`, `css_extractor`, `response_type=markdown\|plaintext` | available |
-| `batch` | ZenRows Batch Scraper API `https://async.api.zenrows.com/v1` (separate host, `X-API-Key` header) — real product in private/invite-only beta. Cloud subcommands (create/status/results/cancel/wait/retry-failed) work WITH beta access; without it the API returns 403 → `BATCH_ACCESS_DENIED`. Local JSONL spec validation + credit estimation work with no key. | beta |
+| `batch` | ZenRows Batch Scraper API `https://async.api.zenrows.com/v1` (separate host, `X-API-Key` header) — real product in beta. Cloud subcommands (create/status/results/cancel/wait/retry-failed) work WITH beta access; without it the API returns 403 → `BATCH_ACCESS_DENIED`. Local JSONL spec validation + credit estimation work with no key. | beta |
 | `browser` | ZenRows Scraping Browser (CDP) + `@zenrows/mcp` `browser_*` tools; no managed REST sessions API | experimental |
 | `mcp` | Hosted `https://mcp.zenrows.com/mcp` + local `npx -y @zenrows/mcp` | available |
 

--- a/recipes/batch-estimate/RECIPE.md
+++ b/recipes/batch-estimate/RECIPE.md
@@ -30,4 +30,4 @@ Once the spec is clean, submit it with beta access:
 ```
 zenrows batch create jobs.jsonl --wait
 ```
-See [[batch-jobs]] for the full cloud flow (invite-only beta).
+See [[batch-jobs]] for the full cloud flow (beta).

--- a/registry/capabilities.json
+++ b/registry/capabilities.json
@@ -21,12 +21,12 @@
     },
     "batch": {
       "key": "batch",
-      "label": "Batch (beta, invite only)",
+      "label": "Batch (beta)",
       "status": "beta",
       "command": "zenrows batch",
       "backend": "Batch Scraper API — https://async.api.zenrows.com/v1 (X-API-Key header; separate host from the scraper /v1/)",
       "requiresAuth": true,
-      "notes": "The ZenRows Batch Scraper API is a real product in private/invite-only beta. The cloud subcommands (create/status/results/cancel/wait/retry-failed) work WITH beta access; without it the API returns 403 → BATCH_ACCESS_DENIED. Local value always works with no key: `zenrows batch estimate` validates JSONL job specs and estimates credit cost."
+      "notes": "The ZenRows Batch Scraper API is a real product in beta. The cloud subcommands (create/status/results/cancel/wait/retry-failed) work WITH beta access; without it the API returns 403 → BATCH_ACCESS_DENIED. Local value always works with no key: `zenrows batch estimate` validates JSONL job specs and estimates credit cost."
     },
     "browser": {
       "key": "browser",

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -36,7 +36,7 @@
     {
       "name": "batch-jobs",
       "type": "skill",
-      "description": "Scale protected fetch/extract over many URLs with the Batch Scraper API (invite-only beta): submit/track/collect jobs with beta access; validate + estimate specs locally with no key.",
+      "description": "Scale protected fetch/extract over many URLs with the Batch Scraper API (beta): submit/track/collect jobs with beta access; validate + estimate specs locally with no key.",
       "status": "beta",
       "requires_backend_capabilities": ["batch"],
       "requires_auth": true,

--- a/registry/templates.json
+++ b/registry/templates.json
@@ -25,7 +25,7 @@
     {
       "name": "batch-jsonl-pipeline",
       "type": "template",
-      "description": "JSONL job-spec scaffold for high-scale workloads on the Batch Scraper API: submit/track/collect with beta access, validate + estimate locally with no key (invite-only beta).",
+      "description": "JSONL job-spec scaffold for high-scale workloads on the Batch Scraper API: submit/track/collect with beta access, validate + estimate locally with no key (beta).",
       "status": "beta",
       "requires_backend_capabilities": [],
       "requires_auth": false,

--- a/skills/batch-jobs/SKILL.md
+++ b/skills/batch-jobs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: batch-jobs
-description: Scale protected fetch/extract over many URLs via the Batch Scraper API (invite-only beta). Cloud create/status/results/cancel/wait/retry-failed work with beta access; estimate/validate run locally with no key.
+description: Scale protected fetch/extract over many URLs via the Batch Scraper API (beta). Cloud create/status/results/cancel/wait/retry-failed work with beta access; estimate/validate run locally with no key.
 version: 0.1.0
 requires_backend_capabilities: [batch]
 ---
@@ -11,8 +11,8 @@ Process large workloads reliably and asynchronously. Batch is where ZenRows'
 high-scale anti-bot advantage becomes obvious — ZenRows wins when the workflow
 runs over thousands, millions, or recurring sets of URLs.
 
-> Status: **beta (invite only)**. The ZenRows Batch Scraper API is a real
-> product in private/invite-only beta and runs on a separate host
+> Status: **beta**. The ZenRows Batch Scraper API is a real
+> product in beta and runs on a separate host
 > (`async.api.zenrows.com/v1`). The cloud subcommands work once your account has
 > beta access; without it the API returns 403 → `BATCH_ACCESS_DENIED`. The
 > toolkit never fakes a cloud run.

--- a/skills/zenrows/SKILL.md
+++ b/skills/zenrows/SKILL.md
@@ -65,7 +65,7 @@ Run `zenrows status` for the live capability matrix. As of this toolkit:
 | --- | --- | --- |
 | Protected Fetch | `zenrows fetch` | available (`GET /v1/`) |
 | Extract (Autoparse/CSS/Markdown) | `zenrows extract` | available (same `/v1/`) |
-| Batch | `zenrows batch` | beta, invite-only (validate specs locally) |
+| Batch | `zenrows batch` | beta (validate specs locally) |
 | Browser | `zenrows browser` | experimental (Scraping Browser / MCP) |
 | MCP | `zenrows mcp` | available (remote + local server) |
 

--- a/src/adapters/batch.ts
+++ b/src/adapters/batch.ts
@@ -1,7 +1,7 @@
 /**
  * Batch Jobs adapter.
  *
- * Status: `beta` — the ZenRows Batch Scraper API is in private/invite-only beta.
+ * Status: `beta` — the ZenRows Batch Scraper API is in beta.
  * With beta access the cloud subcommands run for real (see `core/batch-api.ts`).
  * Without access the API returns 403 → BATCH_ACCESS_DENIED. This adapter owns
  * the local, no-network pieces: validating a JSONL job spec, estimating credit

--- a/src/cli/commands/batch.ts
+++ b/src/cli/commands/batch.ts
@@ -1,5 +1,5 @@
 /**
- * `zenrows batch` — Batch Scraper API (status: beta, invite only).
+ * `zenrows batch` — Batch Scraper API (status: beta).
  *
  * Local (no key, always works): `estimate`/`create --dry-run`-style spec
  * validation + credit estimate. Cloud (needs a key + Batch beta access):

--- a/src/core/batch-api.ts
+++ b/src/core/batch-api.ts
@@ -163,7 +163,7 @@ function problemToError(status: number, body: string, method: string, path: stri
     return new ToolkitError({
       code: "BATCH_ACCESS_DENIED",
       message: "The Batch Scraper API rejected this request (access denied).",
-      likely_cause: `${cause}. The Batch Scraper API is in private beta and this account is not invited.`,
+      likely_cause: `${cause}. The Batch Scraper API is in beta and this account does not have beta access.`,
       next_action:
         "Request Batch Scraper API beta access from ZenRows. Meanwhile validate/estimate specs locally and fan out with `zenrows fetch` per URL.",
       suggested_commands: ["zenrows batch estimate jobs.jsonl"],

--- a/templates/batch-jsonl-pipeline/README.md
+++ b/templates/batch-jsonl-pipeline/README.md
@@ -13,7 +13,7 @@ zenrows batch estimate jobs.example.jsonl    # validate the spec + estimate cred
 
 ## Cloud (needs a key + Batch beta access)
 
-The Batch Scraper API is in **private/invite-only beta**. With beta access the
+The Batch Scraper API is in **beta**. With beta access the
 cloud subcommands run for real; without it the API returns `BATCH_ACCESS_DENIED`.
 
 ```bash

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -9,14 +9,14 @@ test("capability matrix loads with the honest classifications", () => {
   assert.equal(caps.extract?.status, "available");
   assert.equal(caps.browser?.status, "experimental");
   assert.equal(caps.mcp?.status, "available");
-  // Batch is a real product in private/invite-only beta.
+  // Batch is a real product in beta.
   assert.equal(caps.batch?.status, "beta");
 });
 
 test("isUsable true for available, false for absent capabilities", () => {
   assert.equal(isUsable("protected_fetch"), true);
   assert.equal(isUsable("extract"), true);
-  assert.equal(isUsable("batch"), false); // beta is not usable (cloud is invite-only)
+  assert.equal(isUsable("batch"), false); // beta is not usable (cloud needs beta access)
 });
 
 test("assertUsable passes for available + experimental, throws for absent", () => {

--- a/tests/production-surface.test.ts
+++ b/tests/production-surface.test.ts
@@ -13,6 +13,6 @@ test("GA commands remain registered", async () => {
   // --help path returns 0 for a known command without side effects
   assert.equal(await main(["fetch", "--help"]), 0);
   assert.equal(await main(["account", "--help"]), 0);
-  // batch is registered again (beta, invite only) — --help exits 0
+  // batch is registered again (beta) — --help exits 0
   assert.equal(await main(["batch", "--help"]), 0);
 });

--- a/workflows/competitor-intelligence/WORKFLOW.md
+++ b/workflows/competitor-intelligence/WORKFLOW.md
@@ -32,7 +32,7 @@ simple per-URL loop).
    > For large or recurring lists, the **Batch Scraper API** (`zenrows batch`) is
    > the managed alternative — one job submits many URLs, retries transient
    > failures, and stores results, so you don't operate the loop yourself. It's
-   > in invite-only beta; you can request access and validate/estimate a spec
+   > in beta; you can request access and validate/estimate a spec
    > locally today with `zenrows batch estimate jobs.jsonl` (see [[batch-jobs]]).
 4. **Keep fresh.** Schedule the extract step on a recurring basis with cron or
    CI (e.g. a daily GitHub Action that runs `zenrows extract …`).


### PR DESCRIPTION
## Summary
- The Batch Scraper API is now open beta for every account, not gated behind invitations.
- Updates every "invite-only"/"private beta" mention to plain "beta" across README, docs/capabilities.md, the capability matrix (registry/capabilities.json), skills, recipes, templates, workflows, and the BATCH_ACCESS_DENIED error message.
- No functional/gating changes — capability status stays `beta`; only labels, descriptions, and comments changed.

## Test plan
- [x] `npm test` — 115/115 passing
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)