### PR TITLE
ci: add GitHub Actions workflow (typecheck + test on node 20/22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    name: node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test


### PR DESCRIPTION
The repo had no CI, so every green was verified only locally. Add a minimal workflow that runs on pushes to main and on every PR: npm ci → typecheck → build+test (the `test` script builds first), across node 20 and 22 (engines require >=20). This guards the public @zenrows/cli against a red PR landing.

Independent of the in-flight stack (new file, off main) so it can merge on its own and start protecting every subsequent PR.