### PR TITLE
Help-text and MCP-note cleanup (bug bash follow-up)

### DIFF
--- a/src/cli/asset-command.ts
+++ b/src/cli/asset-command.ts
@@ -87,8 +87,8 @@ export function makeAssetCommand(type: AssetType, summary: string): Command {
 function extraUsage(type: AssetType): string {
   if (type === "skill") return "|validate|generate";
   if (type === "template") return "|create";
-  if (type === "recipe") return "|run|explain";
-  if (type === "workflow") return "|run|explain";
+  if (type === "recipe") return "|run";
+  if (type === "workflow") return "|run";
   if (type === "eval") return "|run|report";
   return "";
 }
@@ -97,9 +97,9 @@ function helpFor(type: AssetType): string {
   const lines = [`Manage ${type}s from the installable asset registry.`, ""];
   lines.push("Subcommands:");
   lines.push(`  list                 list all ${type}s in the registry (status-aware)`);
-  lines.push(`  install <name>       copy a ${type} into .zenrows/`);
+  lines.push(`  install <name>       copy ${type === "eval" ? "an" : "a"} ${type} into .zenrows/`);
   if (type === "skill") lines.push("  install --all        install every available skill");
-  lines.push(`  explain <name>       print metadata + docs for a ${type}`);
+  lines.push(`  explain <name>       print metadata + docs for ${type === "eval" ? "an" : "a"} ${type}`);
   lines.push(`  update [name]        reinstall (refresh) installed ${type}s`);
   lines.push(`  remove <name>        remove an installed ${type}`);
   if (type === "template") lines.push("  create <name> --output <dir>   instantiate a template into <dir>");

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -3,6 +3,7 @@
  *   show
  *   get <key>
  *   set <key> <value>
+ *   reset
  */
 import { defaultConfig, loadConfig, saveConfig } from "../../core/config.ts";
 import { log } from "../../core/logger.ts";
@@ -26,7 +27,7 @@ const SETTABLE: Record<string, (c: ToolkitConfig, v: string) => void> = {
 export const config: Command = {
   name: "config",
   summary: "View or update toolkit configuration (non-secret).",
-  usage: "zenrows config <show|get <key>|set <key> <value>>",
+  usage: "zenrows config <show|get <key>|set <key> <value>|reset>",
   run(argv: string[], ctx: RunContext): number {
     const [sub, key, value] = argv;
     const cfg = loadConfig();

--- a/src/installers/mcp/index.ts
+++ b/src/installers/mcp/index.ts
@@ -36,7 +36,6 @@ export const MCP_CLIENTS: Record<string, McpClientSpec> = {
     configFile: ".mcp.json (project) or run `claude mcp add`",
     format: "cli",
     autoConfigurable: true,
-    notes: "Confirmed: `claude mcp add zenrows -e ZENROWS_API_KEY=… -- npx -y @zenrows/mcp`.",
   },
   cursor: {
     id: "cursor",


### PR DESCRIPTION
Stacked on #12 — small, self-contained help-text/DX fixes from the ongoing bug bash that weren't part of the audit-findings pass.

## What
- `workflow`/`recipe --help` showed `explain` twice in the usage string (`<list|install|explain|remove|update|run|explain>`) — `extraUsage()` was appending `|run|explain` on top of the shared base usage, which already includes `explain`. Now appends just `|run`.
- `eval --help` said "copy a eval" / "print metadata + docs for a eval" — fixed to "an eval" in both spots.
- `config --help` never listed the working `reset` subcommand, even though `zenrows config reset` has always worked. Usage string now reads `<show|get <key>|set <key> <value>|reset>`, matching how `policy --help` documents its own `reset`.
- `zenrows mcp config --client claude-code` printed a leftover internal note (`Confirmed: \`claude mcp add zenrows -e ZENROWS_API_KEY=… -- npx -y @zenrows/mcp\`.`) that just repeated the command already shown two lines below it, unlike the genuinely useful vscode/codex notes. Removed.

## Testing
- `npm run build && npm run typecheck && npm test` — clean, 179/179 passing (no test asserted the old strings).
- Manually verified each fix's `--help`/output before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)