### PR TITLE
docs: document extract in batch job specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,22 @@ zenrows batch cancel <job-id>                        # stop an in-flight run
 ```
 
 `jobs.jsonl` is one JSON object per line, each with a `url` (plus optional
-per-line overrides like `js_render`, `premium_proxy`, `proxy_country`). Request
-beta access from Zenrows to run in the cloud; until then, validate/estimate
-locally or fan out with `zenrows fetch` per URL.
+per-line overrides like `js_render`, `premium_proxy`, `proxy_country`,
+`extract`). Request beta access from Zenrows to run in the cloud; until then,
+validate/estimate locally or fan out with `zenrows fetch` per URL.
+
+**Extract in Batch.** Set `"extract": "auto"` on a line to run that URL through
+Extract — structured data instead of raw HTML:
+
+```jsonl
+{"url": "https://example.com/products", "extract": "auto", "external_id": "p1"}
+{"url": "https://example.com/reviews", "extract": "auto", "external_id": "r1"}
+```
+
+An Extract task costs the same as a regular one (1 credit at base tier), so
+`batch estimate` prices it correctly. Results for an Extract task carry two
+keys: `html` (the raw page) and `parsed` (the structured data) — validate a
+sample with `zenrows extract <url>` before running the full batch.
 
 ## 10. Browser Sessions
 

--- a/agent-plugin/skills/batch-jobs/SKILL.md
+++ b/agent-plugin/skills/batch-jobs/SKILL.md
@@ -30,7 +30,9 @@ Optional if exposed by the server: `batch_wait` to block until terminal status.
 1. Validate the workflow on **one** URL with `scrape` or `extract`.
 2. `batch_create` with the full task list (each task: `url` + optional
    overrides like `js_render`, `premium_proxy`, `proxy_country`, `mode`,
-   `autoparse`, `external_id`, `metadata`).
+   `autoparse`, `extract`, `external_id`, `metadata`). `extract: "auto"`
+   returns structured data instead of raw HTML, at the same credit cost as a
+   regular task; the result carries `html` and `parsed` keys.
 3. Poll `batch_status` until terminal (`completed` / `stopped` / …).
 4. Collect with `batch_results`.
 5. `batch_cancel` if the user aborts or the run should stop early.

--- a/skills/batch-jobs/SKILL.md
+++ b/skills/batch-jobs/SKILL.md
@@ -24,7 +24,21 @@ zenrows batch estimate jobs.jsonl     # validate the spec + estimate credits
 
 `jobs.jsonl` is one JSON object per line, each with a `url` (plus optional
 per-task keys: `external_id`, `metadata`, and scrape params like `js_render`,
-`premium_proxy`, `proxy_country`, `mode`, `autoparse`).
+`premium_proxy`, `proxy_country`, `mode`, `autoparse`, `extract`).
+
+## Extract in Batch
+
+`"extract": "auto"` on a line runs that URL through Extract, returning
+structured data instead of raw HTML.
+
+```
+{"url": "https://example.com/products", "extract": "auto", "external_id": "p1"}
+```
+
+An Extract task costs the same as a regular one (1 credit at base tier), so
+`batch estimate` prices it correctly. The result carries two keys: `html` (the
+raw page) and `parsed` (the structured data). Validate on a single URL with
+`zenrows extract <url>` before running the full batch.
 
 ## Cloud (needs a key + beta access)
 ```

--- a/templates/batch-jsonl-pipeline/README.md
+++ b/templates/batch-jsonl-pipeline/README.md
@@ -3,7 +3,12 @@
 Scaffold for a high-scale workload expressed as a JSONL job spec, run on the
 Zenrows **Batch**. One JSON object per line, each with a `url` (plus
 optional per-line overrides like `js_render`, `premium_proxy`, `proxy_country`,
-`mode`, `autoparse`, and an `external_id` echoed back on each result).
+`mode`, `autoparse`, `extract`, and an `external_id` echoed back on each
+result).
+
+Set `"extract": "auto"` on a line to run that URL through Extract — structured
+data instead of raw HTML, at the same credit cost as a regular task. Extract
+results carry `html` and `parsed` keys.
 
 ## Local (no key)
 

--- a/templates/batch-jsonl-pipeline/jobs.example.jsonl
+++ b/templates/batch-jsonl-pipeline/jobs.example.jsonl
@@ -1,3 +1,4 @@
 {"url": "https://www.scrapingcourse.com/ecommerce/", "mode": "auto", "autoparse": true}
 {"url": "https://httpbin.io/html"}
 {"url": "https://example.com", "js_render": true, "premium_proxy": true}
+{"url": "https://www.scrapingcourse.com/ecommerce/", "extract": "auto", "external_id": "extract-demo"}


### PR DESCRIPTION
`extract` works per-line in a batch JSONL spec today — it passes through to `zenrows_params` and Conveyor honors it — but nothing documented it. Adds it to the README, both `batch-jobs` skills, and the JSONL pipeline template.

Verified against a real batch run (job `01M0WPG13YHFQTW7HQM2GEZMM6`):

- an Extract task returns `{html, parsed}`
- it costs 1 credit at base tier, and `batch estimate` already prices it correctly

`extract_fields` is deliberately **not** documented — any value currently returns an empty `parsed` while the task reports `successful` and still bills. Filed separately against ENG-230.