### PR TITLE
Point the skills at auto mode before manual escalation

### DIFF
--- a/skills/extract/SKILL.md
+++ b/skills/extract/SKILL.md
@@ -31,6 +31,7 @@ zenrows extract <url> --validate                   # fail if not valid JSON
 - If Autoparse misses fields, switch to `--css` with explicit selectors. Auto
   mode already renders JS when the target needs it, so reach for
   `--manual --js-render` only after auto mode has returned an incomplete page:
-  it costs 5 credits per request against 1, and it makes the escalation yours.
+  it costs several times a basic call ([[cost-control]]) and it makes the
+  escalation yours.
 
 See [[protected-fetch]] for retrieval semantics.

--- a/skills/extract/SKILL.md
+++ b/skills/extract/SKILL.md
@@ -28,7 +28,9 @@ zenrows extract <url> --validate                   # fail if not valid JSON
 
 ## Rules
 - Validate on a single page before scaling across many URLs.
-- If Autoparse misses fields, switch to `--css` with explicit selectors, or add
-  `--manual --js-render` for JS-heavy pages.
+- If Autoparse misses fields, switch to `--css` with explicit selectors. Auto
+  mode already renders JS when the target needs it, so reach for
+  `--manual --js-render` only after auto mode has returned an incomplete page:
+  it costs 5 credits per request against 1, and it makes the escalation yours.
 
 See [[protected-fetch]] for retrieval semantics.

--- a/skills/protected-fetch/SKILL.md
+++ b/skills/protected-fetch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: protected-fetch
-description: Use Zenrows Protected Fetch for anti-bot-protected page retrieval.
+description: Use Zenrows Protected Fetch in auto mode for anti-bot-protected page retrieval. Auto mode handles the anti-bot escalation, so never enable JS rendering or premium proxies yourself on a first attempt.
 version: 0.1.0
 requires_backend_capabilities: [protected_fetch]
 ---
@@ -16,18 +16,32 @@ cannot. This is the **core primitive** — backed by Zenrows **Fetch**
 - The target has anti-bot protection, needs JS rendering, or geo-specific access.
 
 ## How to call
+
+Auto mode is the answer for anti-bot targets, Cloudflare included. It escalates
+for you and bills only for the configuration that succeeds.
+
 ```
-zenrows fetch <url>                       # Adaptive Stealth Mode (recommended)
+zenrows fetch <url>                       # Adaptive Stealth Mode. Start here, always
 zenrows fetch <url> --output markdown     # convert to Markdown
-zenrows fetch <url> --manual --js-render --premium-proxy   # full manual control
-zenrows fetch <url> --proxy-country us    # geo-target (auto mode; in manual mode needs --premium-proxy)
+zenrows fetch <url> --proxy-country us    # geo-target, works in auto mode
 zenrows fetch <url> --wait-for ".price"   # wait for a selector
 ```
 
+Manual mode exists for the rare case where auto mode has already failed and a
+trace shows why. It costs more and it makes the escalation your problem:
+
+```
+zenrows fetch <url> --manual --js-render --premium-proxy   # 25 credits per request
+```
+
 ## Rules
-- Start with **auto mode**. In auto mode, `js_render` and `premium_proxy` are
-  managed for you — passing them manually requires `--manual`
-  (otherwise you get `PARAM_CONFLICT_AUTO_MANUAL`).
+- Start with **auto mode**. Enabling `--js-render` and `--premium-proxy` yourself
+  costs 25 credits per request against 1 for a basic call, and auto mode reaches
+  the same configuration only when the target actually needs it.
+- A hard target is not a reason to skip auto mode. It is the reason auto mode
+  exists.
+- In auto mode `js_render` and `premium_proxy` are managed for you. Passing them
+  manually requires `--manual`, otherwise you get `PARAM_CONFLICT_AUTO_MANUAL`.
 - `--proxy-country` works in auto mode on its own; in `--manual` mode it also
   needs `--premium-proxy` (else `PARAM_PROXY_COUNTRY_REQUIRES_PREMIUM`).
 - You are billed only for the configuration that succeeds.

--- a/skills/protected-fetch/SKILL.md
+++ b/skills/protected-fetch/SKILL.md
@@ -31,13 +31,14 @@ Manual mode exists for the rare case where auto mode has already failed and a
 trace shows why. It costs more and it makes the escalation your problem:
 
 ```
-zenrows fetch <url> --manual --js-render --premium-proxy   # 25 credits per request
+zenrows fetch <url> --manual --js-render --premium-proxy   # the most expensive path, see [[cost-control]]
 ```
 
 ## Rules
 - Start with **auto mode**. Enabling `--js-render` and `--premium-proxy` yourself
-  costs 25 credits per request against 1 for a basic call, and auto mode reaches
-  the same configuration only when the target actually needs it.
+  is the most expensive configuration this API offers, by a wide margin, and auto
+  mode reaches the same place only when the target actually needs it. The
+  multipliers are in [[cost-control]].
 - A hard target is not a reason to skip auto mode. It is the reason auto mode
   exists.
 - In auto mode `js_render` and `premium_proxy` are managed for you. Passing them

--- a/skills/trace-debug/SKILL.md
+++ b/skills/trace-debug/SKILL.md
@@ -19,8 +19,11 @@ zenrows trace export <run-id>     # JSON for sharing
 ```
 
 ## Failure → action map
-- `FETCH_FAILED` / empty content → retry `--manual --js-render`, then add
-  `--premium-proxy`; for slow pages add `--wait-for <selector>`.
+- `FETCH_FAILED` / empty content → first retry in auto mode (`mode=auto`), which
+  escalates for you and bills only for what succeeds. For slow pages add
+  `--wait-for <selector>`. Only when auto mode has failed on its own, take
+  manual control with `--manual --js-render` (5 credits per request), then
+  `--premium-proxy` (25 with both, against 1 for a basic call).
 - `REQUEST_TIMEOUT` → the CLI stopped waiting; the API was reached. Raise
   `--timeout` (default 120000ms, above the API's own 90s budget), or drop
   `--wait-for` so the request finishes inside that budget and the API returns

--- a/skills/trace-debug/SKILL.md
+++ b/skills/trace-debug/SKILL.md
@@ -22,8 +22,9 @@ zenrows trace export <run-id>     # JSON for sharing
 - `FETCH_FAILED` / empty content → first retry in auto mode (`mode=auto`), which
   escalates for you and bills only for what succeeds. For slow pages add
   `--wait-for <selector>`. Only when auto mode has failed on its own, take
-  manual control with `--manual --js-render` (5 credits per request), then
-  `--premium-proxy` (25 with both, against 1 for a basic call).
+  manual control with `--manual --js-render`, then `--premium-proxy`. Each step
+  multiplies the cost of the request, and both together are the most expensive
+  configuration available ([[cost-control]]).
 - `REQUEST_TIMEOUT` → the CLI stopped waiting; the API was reached. Raise
   `--timeout` (default 120000ms, above the API's own 90s budget), or drop
   `--wait-for` so the request finishes inside that budget and the API returns


### PR DESCRIPTION
## Problem

Given a plain "fetch this bot-protected page" question, with no mention of configuration or cost, an agent reading our skills recommended `premium_proxy` in **7 of 8** runs.

That pair with `js_render` is the most expensive configuration the API offers. `mode=auto` exists so the agent never has to make that call itself, and it bills only for the configuration that succeeds.

## Cause

Three skills sold escalation as ordinary practice.

`protected-fetch` said to start with auto mode, then listed this as a peer example with no cost attached:

```
zenrows fetch <url> --manual --js-render --premium-proxy   # full manual control
```

"Full manual control" reads like the serious option for a hard target, and the cost model lived in a different file. Advice at the point of temptation beats advice somewhere else.

`extract` offered `--manual --js-render` as an ordinary fix for missing fields, never mentioning that auto mode already renders JS when the target needs it.

`trace-debug` sent the agent from `FETCH_FAILED` straight to `--manual --js-render` and then `--premium-proxy`, with no mention of auto mode at all.

## Change

Manual mode moves out of the auto examples into its own block and is framed as what you reach for after auto mode has already failed and a trace shows why. `extract` and `trace-debug` now point at auto mode first. The `protected-fetch` frontmatter description carries it too, since that part is always loaded.

No prices are repeated. Each warning names the direction and points at `cost-control`, which owns the multiplier table. A figure copied into four files goes stale in four files.

## Result

Measured with the harness in #20, 8 runs, one variable changed:

| | before | after |
| --- | --- | --- |
| picks the CLI | 8/8 | 8/8 |
| grounded advice | 8/8 | 8/8 |
| **reaches for an escalation, never mentions auto mode** | **7/8** | **0/8** |

Every run now chooses auto mode, and most say so explicitly: "no JS rendering or premium proxies on the first attempt, since auto mode handles the escalation".

## Scope

Three markdown files under `skills/`. No code, and no behaviour change in the CLI itself. It reaches anyone already receiving these skills through `zenrows plugin install` or the `agent-plugin` package, independent of any other change.

#20 stacks on this branch and adds a deterministic test that fails the build if a skill regresses this way again.